### PR TITLE
feat: Cohort VO 테스트 및 예외 처리 개선 (#3)

### DIFF
--- a/module-domain/src/main/java/com/longrunpc/domain/cohort/entity/CohortMember.java
+++ b/module-domain/src/main/java/com/longrunpc/domain/cohort/entity/CohortMember.java
@@ -17,6 +17,7 @@ import lombok.Builder;
 import java.util.Objects;
 
 import com.longrunpc.common.constant.cohort.CohortConstants;
+import com.longrunpc.common.error.CohortErrorCode;
 import com.longrunpc.common.error.GlobalErrorCode;
 import com.longrunpc.common.exception.BusinessException;
 import com.longrunpc.domain.cohort.vo.Deposit;
@@ -78,10 +79,6 @@ public class CohortMember extends BaseEntity {
             .build();
     }
 
-    public boolean isDepositEnough(int amount) {
-        return this.deposit.getValue() >= amount;
-    }
-
     public void increaseDeposit(int amount) {
         if (amount < 0) {
             throw new BusinessException(GlobalErrorCode.INVALID_INPUT);
@@ -93,10 +90,23 @@ public class CohortMember extends BaseEntity {
         if (amount < 0) {
             throw new BusinessException(GlobalErrorCode.INVALID_INPUT);
         }
+        if (this.deposit.getValue() < amount) {
+            throw new BusinessException(CohortErrorCode.DEPOSIT_INSUFFICIENT);
+        }
         this.deposit = new Deposit(this.deposit.getValue() - amount);
     }
 
     public void increaseExcusedCount() {
+        if (this.excusedCount.getValue() >= CohortConstants.MAX_EXCUSED_COUNT) {
+            throw new BusinessException(CohortErrorCode.EXCUSE_LIMIT_EXCEEDED);
+        }
         this.excusedCount = new ExcusedCount(this.excusedCount.getValue() + 1);
+    }
+
+    public void decreaseExcusedCount() {
+        if (this.excusedCount.getValue() <= CohortConstants.INITIAL_EXCUSED_COUNT) {
+            throw new BusinessException(GlobalErrorCode.INTERNAL_ERROR);
+        }
+        this.excusedCount = new ExcusedCount(this.excusedCount.getValue() - 1);
     }
 }

--- a/module-domain/src/test/java/com/longrunpc/domain/cohort/entity/CohortMemeber.java
+++ b/module-domain/src/test/java/com/longrunpc/domain/cohort/entity/CohortMemeber.java
@@ -21,6 +21,7 @@ import com.longrunpc.domain.cohort.vo.Generation;
 import com.longrunpc.domain.cohort.vo.PartName;
 import com.longrunpc.domain.cohort.vo.TeamName;
 import com.longrunpc.common.constant.cohort.CohortConstants;
+import com.longrunpc.common.exception.BusinessException;
 
 @DisplayName("CohortMember 엔티티 테스트")
 public class CohortMemeber {
@@ -100,32 +101,6 @@ public class CohortMemeber {
         }
     }
 
-    @DisplayName("isDepositEnough 메서드 테스트")
-    @Nested
-    class IsDepositEnoughTest {
-        @DisplayName("deposit 잔액 충분 시 true 반환")
-        @Test
-        void should_return_true_when_deposit_is_enough() {
-            // given
-            CohortMember cohortMember = CohortMember.createCohortMember(member, cohort, part, team);
-            // when
-            boolean result = cohortMember.isDepositEnough(CohortConstants.INITIAL_DEPOSIT);
-            // then
-            assertThat(result).isTrue();
-        }
-
-        @DisplayName("deposit 잔액 부족 시 false 반환")
-        @Test
-        void should_return_false_when_deposit_is_not_enough() {
-            // given
-            CohortMember cohortMember = CohortMember.createCohortMember(member, cohort, part, team);
-            // when
-            boolean result = cohortMember.isDepositEnough(CohortConstants.INITIAL_DEPOSIT + 1);
-            // then
-            assertThat(result).isFalse();
-        }
-    }
-
     @DisplayName("increaseDeposit 메서드 테스트")
     @Nested
     class IncreaseDepositTest {
@@ -147,7 +122,7 @@ public class CohortMemeber {
             CohortMember cohortMember = CohortMember.createCohortMember(member, cohort, part, team);
             // when & then
             assertThatThrownBy(() -> cohortMember.increaseDeposit(-1))
-                .isInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(BusinessException.class);
         }
     }
 
@@ -172,7 +147,17 @@ public class CohortMemeber {
             CohortMember cohortMember = CohortMember.createCohortMember(member, cohort, part, team);
             // when & then
             assertThatThrownBy(() -> cohortMember.decreaseDeposit(-1))
-                .isInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(BusinessException.class);
+        }
+
+        @DisplayName("deposit 잔액 부족 시 예외 발생")
+        @Test
+        void should_throw_exception_when_deposit_is_not_enough() {
+            // given
+            CohortMember cohortMember = CohortMember.createCohortMember(member, cohort, part, team);
+            // when & then
+            assertThatThrownBy(() -> cohortMember.decreaseDeposit(CohortConstants.INITIAL_DEPOSIT + 1))
+                .isInstanceOf(BusinessException.class);
         }
     }
 
@@ -206,7 +191,49 @@ public class CohortMemeber {
 
             // when & then
             assertThatThrownBy(() -> cohortMember.increaseExcusedCount())
-                .isInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(BusinessException.class);
+        }
+    }
+
+    @DisplayName("decreaseExcusedCount 메서드 테스트")
+    @Nested
+    class DecreaseExcusedCountTest {
+        @DisplayName("공결 횟수 감소 시 정상 작동")
+        @Test
+        void should_decrease_excused_count_when_valid_input() {
+            // given
+            CohortMember cohortMember = CohortMember.builder()
+                .id(1L)
+                .member(member)
+                .cohort(cohort)
+                .part(part)
+                .team(team)
+                .deposit(new Deposit(CohortConstants.INITIAL_DEPOSIT))
+                .excusedCount(new ExcusedCount(1))
+                .build();
+            // when
+            cohortMember.decreaseExcusedCount();
+            // then
+            assertThat(cohortMember.getExcusedCount()).isEqualTo(new ExcusedCount(0));
+        }
+
+        @DisplayName("공결 횟수 0 이하 시 예외 발생")
+        @Test
+        void should_throw_exception_when_zero_input() {
+            // given
+            CohortMember cohortMember = CohortMember.builder()
+                .id(1L)
+                .member(member)
+                .cohort(cohort)
+                .part(part)
+                .team(team)
+                .deposit(new Deposit(CohortConstants.INITIAL_DEPOSIT))
+                .excusedCount(new ExcusedCount(0))
+                .build();
+            
+            // when & then
+            assertThatThrownBy(() -> cohortMember.decreaseExcusedCount())
+                .isInstanceOf(BusinessException.class);
         }
     }
 }

--- a/module-domain/src/test/java/com/longrunpc/domain/cohort/vo/DepositTest.java
+++ b/module-domain/src/test/java/com/longrunpc/domain/cohort/vo/DepositTest.java
@@ -1,0 +1,37 @@
+package com.longrunpc.domain.cohort.vo;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.longrunpc.common.exception.BusinessException;
+
+@DisplayName("Deposit 테스트")
+public class DepositTest {
+    
+    @DisplayName("올바른 값으로 생성 시 정상 생성")
+    @Test
+    void should_create_deposit_when_valid_input() {
+        // given
+        int value = 100_000;
+
+        // when
+        Deposit deposit = new Deposit(value);
+
+        // then
+        assertThat(deposit.getValue()).isEqualTo(value);
+    }
+
+    @DisplayName("음수 값으로 생성 시 예외 발생")
+    @Test
+    void should_throw_exception_when_negative_input() {
+        // given
+        int value = -1;
+        
+        // when & then
+        assertThatThrownBy(() -> new Deposit(value))
+            .isInstanceOf(BusinessException.class);
+    }
+}

--- a/module-domain/src/test/java/com/longrunpc/domain/cohort/vo/ExcusedCountTest.java
+++ b/module-domain/src/test/java/com/longrunpc/domain/cohort/vo/ExcusedCountTest.java
@@ -1,0 +1,49 @@
+package com.longrunpc.domain.cohort.vo;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.longrunpc.common.constant.cohort.CohortConstants;
+import com.longrunpc.common.exception.BusinessException;
+
+@DisplayName("ExcusedCount 테스트")
+public class ExcusedCountTest {
+
+    @DisplayName("올바른 값으로 생성 시 정상 생성")
+    @Test
+    void should_create_excused_count_when_valid_input() {
+        // given
+        int value = 1;
+
+        // when
+        ExcusedCount excusedCount = new ExcusedCount(value);
+
+        // then
+        assertThat(excusedCount.getValue()).isEqualTo(value);
+    }
+
+    @DisplayName("음수 값으로 생성 시 예외 발생")
+    @Test
+    void should_throw_exception_when_negative_input() {
+        // given
+        int value = -1;
+
+        // when & then
+        assertThatThrownBy(() -> new ExcusedCount(value))
+            .isInstanceOf(BusinessException.class);
+    }
+
+    @DisplayName("초과 값으로 생성 시 예외 발생")
+    @Test
+    void should_throw_exception_when_exceed_input() {
+        // given
+        int value = CohortConstants.MAX_EXCUSED_COUNT + 1;
+        
+        // when & then
+        assertThatThrownBy(() -> new ExcusedCount(value))
+            .isInstanceOf(BusinessException.class);
+    }
+}

--- a/module-domain/src/test/java/com/longrunpc/domain/cohort/vo/GenerationTest.java
+++ b/module-domain/src/test/java/com/longrunpc/domain/cohort/vo/GenerationTest.java
@@ -1,0 +1,44 @@
+package com.longrunpc.domain.cohort.vo;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.longrunpc.common.exception.BusinessException;
+
+@DisplayName("Generation 테스트")  
+public class GenerationTest {
+
+    @DisplayName("올바른 값으로 생성 시 정상 생성")
+    @Test
+    void should_create_generation_when_valid_input() {
+        // given
+        String value = "2026";
+        // when
+        Generation generation = new Generation(value);
+        // then
+        assertThat(generation.getValue()).isEqualTo(value);
+    }
+
+    @DisplayName("null 값으로 생성 시 예외 발생")
+    @Test
+    void should_throw_exception_when_null_input() {
+        // given
+        String value = null;
+        // when & then
+        assertThatThrownBy(() -> new Generation(value))
+            .isInstanceOf(BusinessException.class);
+    }
+
+    @DisplayName("빈 문자열로 생성 시 예외 발생")
+    @Test
+    void should_throw_exception_when_empty_input() {
+        // given
+        String value = "";
+        // when & then
+        assertThatThrownBy(() -> new Generation(value))
+            .isInstanceOf(BusinessException.class);
+    }
+}

--- a/module-domain/src/test/java/com/longrunpc/domain/cohort/vo/PartNameTest.java
+++ b/module-domain/src/test/java/com/longrunpc/domain/cohort/vo/PartNameTest.java
@@ -1,0 +1,44 @@
+package com.longrunpc.domain.cohort.vo;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.longrunpc.common.exception.BusinessException;
+
+@DisplayName("PartName 테스트")
+public class PartNameTest {
+    
+    @DisplayName("올바른 값으로 생성 시 정상 생성")
+    @Test
+    void should_create_part_name_when_valid_input() {
+        // given
+        String value = "test";
+        // when
+        PartName partName = new PartName(value);
+        // then
+        assertThat(partName.getValue()).isEqualTo(value);
+    }
+
+    @DisplayName("null 값으로 생성 시 예외 발생")
+    @Test
+    void should_throw_exception_when_null_input() {
+        // given
+        String value = null;
+        // when & then
+        assertThatThrownBy(() -> new PartName(value))
+            .isInstanceOf(BusinessException.class);
+    }
+
+    @DisplayName("빈 문자열로 생성 시 예외 발생")
+    @Test
+    void should_throw_exception_when_empty_input() {
+        // given
+        String value = "";
+        // when & then
+        assertThatThrownBy(() -> new PartName(value))
+            .isInstanceOf(BusinessException.class);
+    }
+}

--- a/module-domain/src/test/java/com/longrunpc/domain/cohort/vo/TeamNameTest.java
+++ b/module-domain/src/test/java/com/longrunpc/domain/cohort/vo/TeamNameTest.java
@@ -1,0 +1,43 @@
+package com.longrunpc.domain.cohort.vo;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.longrunpc.common.exception.BusinessException;
+
+@DisplayName("TeamName 테스트")
+public class TeamNameTest {
+    @DisplayName("올바른 값으로 생성 시 정상 생성")
+    @Test
+    void should_create_team_name_when_valid_input() {
+        // given
+        String value = "test";
+        // when
+        TeamName teamName = new TeamName(value);
+        // then
+        assertThat(teamName.getValue()).isEqualTo(value);
+    }
+
+    @DisplayName("null 값으로 생성 시 예외 발생")
+    @Test
+    void should_throw_exception_when_null_input() {
+        // given
+        String value = null;
+        // when & then
+        assertThatThrownBy(() -> new TeamName(value))
+            .isInstanceOf(BusinessException.class);
+    }
+
+    @DisplayName("빈 문자열로 생성 시 예외 발생")
+    @Test
+    void should_throw_exception_when_empty_input() {
+        // given
+        String value = "";
+        // when & then
+        assertThatThrownBy(() -> new TeamName(value))
+            .isInstanceOf(BusinessException.class);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
resolves: #3 
## 📝작업 내용
- CohortMember 도메인 로직 수정: 
  - `isDepositEnough` 메서드를 제거하고, `decreaseDeposit` 메서드에서 잔액 부족 시 `BusinessException`을 발생시키도록 개선하였습니다.
  - `increaseExcusedCount` 메서드에서 최대 공결 횟수를 초과할 경우 예외를 발생시키도록 추가
  - `decreaseExcusedCount` 메서드를 추가하여 공결 횟수를 감소시키는 기능을 구현하고, 공결 횟수가 0 이하일 경우 예외를 발생

- Cohort 관련 VO 테스트 추가
